### PR TITLE
Fixed Bug - can now remove items from cart

### DIFF
--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -77,7 +77,8 @@ class LineItems(ViewSet):
         try:
             customer = Customer.objects.get(user=request.auth.user)
             order_product = OrderProduct.objects.get(pk=pk, order__customer=customer)
-
+            order_product.delete()
+            
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 
         except OrderProduct.DoesNotExist as ex:


### PR DESCRIPTION
Can remove a single item from user's cart

## Changes

- added `order_product.delete()` to lineitem viewset under the delete method

## Requests / Responses

**Request**

DELETE `/lineitem/4` removes that item from the cart


**Response**

HTTP/1.1 204 No Content 


## Testing

Description of how to test code...

- [ ] fetch/checkout to `bug-removeItemFromCart`
- [ ] run server
- [ ] GET `http://localhost:8000/profile/cart` to see current line items
- [ ] GET `http://localhost:8000/lineitems/4` to see item to be deleted
- [ ] DELETE `http://localhost:8000/lineitems/4` and see 204 No Content response
- [ ] verify by GET `http://localhost:8000/profile/cart` again to see line item 4 deleted


## Related Issues

- Fixes #20