### PR TITLE
Bug - resolved all payment types showing for current user

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -81,10 +81,10 @@ class Payments(ViewSet):
         """Handle GET requests to payment type resource"""
         payment_types = Payment.objects.all()
 
-        customer_id = self.request.query_params.get('customer', None)
+        customer = request.auth.user
 
-        if customer_id is not None:
-            payment_types = payment_types.filter(customer__id=customer_id)
+        if customer is not None:
+            payment_types = payment_types.filter(customer__id=customer.id)
 
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -20,7 +20,7 @@ class PaymentSerializer(serializers.HyperlinkedModelSerializer):
             lookup_field='id'
         )
         fields = ('id', 'url', 'merchant_name', 'account_number',
-                  'expiration_date', 'create_date')
+                  'expiration_date', 'create_date', 'customer_id')
 
 
 class Payments(ViewSet):
@@ -81,10 +81,11 @@ class Payments(ViewSet):
         """Handle GET requests to payment type resource"""
         payment_types = Payment.objects.all()
 
-        customer = request.auth.user
+        customer = Customer.objects.get(user=request.auth.user)
+        customer_id = customer.id
 
-        if customer is not None:
-            payment_types = payment_types.filter(customer__id=customer.id)
+        if customer_id is not None:
+            payment_types = payment_types.filter(customer__id=customer_id)
 
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})


### PR DESCRIPTION
Resolved all payment types being returned in response for current user

## Changes

- grabbed the currently logged-in user id
- filtered against the current user in list method under payment viewset

## Requests / Responses

**Request**

GET `/paymenttypes` returns all payment types

Using `Token 9ba45f09651c5b0c404f37a2d2572c026c14669c` only returns payment type for Brenda

```json
{
        "id": 1,
        "url": "http://localhost:8000/paymenttypes/1",
        "merchant_name": "Visa",
        "account_number": "24ijio68948fj8439",
        "expiration_date": "2020-01-01",
        "create_date": "2019-11-11"
    },
    {
        "id": 2,
        "url": "http://localhost:8000/paymenttypes/2",
        "merchant_name": "Mastercard",
        "account_number": "39j3984fj9sofi9",
        "expiration_date": "2020-02-01",
        "create_date": "2019-12-12"
    },
    {
        "id": 3,
        "url": "http://localhost:8000/paymenttypes/3",
        "merchant_name": "Visa",
        "account_number": "fj0398fjw0g89434",
        "expiration_date": "2020-03-01",
        "create_date": "2019-03-11"
    }
```

**Response**

HTTP/1.1 200 OK

```json
 {
        "id": 3,
        "url": "http://localhost:8000/paymenttypes/3",
        "merchant_name": "Visa",
        "account_number": "fj0398fjw0g89434",
        "expiration_date": "2020-03-01",
        "create_date": "2019-03-11",
        "customer_id": 7
    }
```

## Testing

- [ ] fetch/checkout to `bug-paymentTypes`
- [ ] run server
- [ ] GET `http://localhost:8000/paymenttypes` to show response of one payment type using Brenda's Token 9ba45f09651c5b0c404f37a2d2572c026c14669c


## Related Issues

- Fixes #18