### PR TITLE
Bug - fixed request.data assignment of expiration and created date

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -34,8 +34,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()


### PR DESCRIPTION

## Changes

- Revised lines 37 & 38 of paymenttype.py to assign the correct request data being stored for expiration and create dates when creating a new payment type.

## Requests / Responses

Using `Token 9ba45f09651c5b0c404f37a2d2572c026c146690`

**Request**

POST `http://localhost:8000/paymenttypes`  Creates a new payment type

```json
{
    "merchant_name": "Amex",
    "account_number": "000000000000",
    "expiration_date": "2023-12-12",
    "create_date": "2020-12-12"
}
```

**Response**

HTTP/1.1 201 Created 

```json
{
    "id": 4,
    "url": "http://localhost:8000/paymenttypes/4",
    "merchant_name": "Amex",
    "account_number": "000000000000",
    "expiration_date": "2023-12-12",
    "create_date": "2020-12-12"
}
```

## Testing

- [ ] fetch/chekcout to bug-paymentInfoIncorrect
- [ ] run server
- [ ] run a POST to http://localhost:8000/paymenttypes and verify that the data comes back the same way you sent it and creates a new payment with a 201 Created.


## Related Issues

- Fixes #19