### PR TITLE
Bug - Incorrect result for minimum products sold

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -268,7 +268,7 @@ class Products(ViewSet):
 
         if number_sold is not None:
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                if product.number_sold >= int(number_sold):
                     return True
                 return False
 


### PR DESCRIPTION

## Changes

- Revised line 271 in product.py view - logic for filtering products sold now checks if the number sold is greater than or equal to instead of less than `>=`  not `<=`

## Requests / Responses

**Request**

GET `http://localhost:8000/products?number_sold=2` returns the one item sold twice

```json
{
        "id": 50,
        "name": "Escalade EXT",
        "price": 926.92,
        "number_sold": 2,
        "description": "2008 Cadillac",
        "quantity": 2,
        "created_date": "2019-02-01",
        "location": "Lokavec",
        "image_path": null,
        "average_rating": 3.25
    }
```

**Response**

HTTP/1.1 200 OK


## Testing

Description of how to test code...

- [ ] fetch/checkout to `bug-minimumProductSold`
- [ ] run server
- [ ] GET `http://localhost:8000/products?number_sold=2` and verify the Escalade is the only object returned.


## Related Issues

- Fixes #21