### PR TITLE
Feature - added min_price filter feature

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -250,6 +250,7 @@ class Products(ViewSet):
         order = self.request.query_params.get('order_by', None)
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
+        min_price = self.request.query_params.get('min_price', None)
 
         if order is not None:
             order_filter = order
@@ -273,6 +274,15 @@ class Products(ViewSet):
                 return False
 
             products = filter(sold_filter, products)
+        
+        if min_price is not None:
+            def price_filter(product):
+                if product.price >= float(min_price):
+                    return True
+                return False
+
+            products = filter(price_filter, products)
+
 
         serializer = ProductSerializer(
             products, many=True, context={'request': request})


### PR DESCRIPTION
## Changes

- added `min_price` query param on line 253 in `views/product.py`
- added if conditional and method to filter products by price and only show products `>=` to the price set in the query string parameter.

## Requests / Responses

**Request**

GET `http://localhost:8000/products?min_price=1900` gets products priced $1,900 or higher

```json
{
        "id": 20,
        "name": "Mazda6",
        "price": 1900.67,
        "number_sold": 1,
        "description": "2005 Mazda",
        "quantity": 2,
        "created_date": "2018-12-13",
        "location": "Tuburan",
        "image_path": null,
        "average_rating": 0
    },
    {
        "id": 32,
        "name": "DB9",
        "price": 1912.51,
        "number_sold": 0,
        "description": "2008 Aston Martin",
        "quantity": 3,
        "created_date": "2019-01-06",
        "location": "Paris 07",
        "image_path": null,
        "average_rating": 0
    },
    {
        "id": 41,
        "name": "Impreza",
        "price": 1913.81,
        "number_sold": 0,
        "description": "1998 Subaru",
        "quantity": 4,
        "created_date": "2019-03-15",
        "location": "Dingjiaqiao",
        "image_path": null,
        "average_rating": 0
    },
    {
        "id": 60,
        "name": "Elantra",
        "price": 1989.84,
        "number_sold": 0,
        "description": "1994 Hyundai",
        "quantity": 1,
        "created_date": "2019-01-19",
        "location": "Sosnovoborsk",
        "image_path": null,
        "average_rating": 0
    }
```

**Response**

HTTP/1.1 200 OK

## Testing

Description of how to test code...

- [ ] fetch/checkout to `feature-productsOverPrice`
- [ ] run server
- [ ] GET `http://localhost:8000/products?min_price=1900` in postman
- [ ] verify only products priced $1900 and over come back in response


## Related Issues

- Fixes #17